### PR TITLE
Fix deleteTodo response

### DIFF
--- a/apps/backend/src/features/todos/controllers.ts
+++ b/apps/backend/src/features/todos/controllers.ts
@@ -82,7 +82,7 @@ export const deleteTodo = async (c: Context) => {
     if (!deletedTodo.length) {
       return c.json({ error: 'Todo not found' }, 404);
     }
-    return c.json({ message: 'Todo deleted successfully' }, 204);
+    return c.json({ message: 'Todo deleted successfully' }, 200);
   } catch (error: any) {
     return c.json({ error: error.message }, 500);
   }

--- a/apps/backend/src/features/todos/routes.ts
+++ b/apps/backend/src/features/todos/routes.ts
@@ -204,8 +204,18 @@ const deleteTodoRoute = createRoute({
     })
   },
   responses: {
-    204: {
-      description: '削除成功'
+    200: {
+      description: '削除成功',
+      content: {
+        'application/json': {
+          schema: z.object({
+            message: z.string().openapi({
+              description: '成功メッセージ',
+              example: 'Todo deleted successfully'
+            })
+          })
+        }
+      }
     },
     404: {
       description: 'Todoが見つかりません',

--- a/apps/backend/src/test/features/todos/controllers.test.ts
+++ b/apps/backend/src/test/features/todos/controllers.test.ts
@@ -211,7 +211,7 @@ describe('Todo Controllers', () => {
       const result = await deleteTodo(mockContext);
 
       expect(mockContext.req.param).toHaveBeenCalledWith('id');
-      expect(mockContext.json).toHaveBeenCalledWith({ message: 'Todo deleted successfully' }, 204);
+      expect(mockContext.json).toHaveBeenCalledWith({ message: 'Todo deleted successfully' }, 200);
     });
 
     it('should return 404 if todo not found', async () => {

--- a/apps/backend/src/test/features/todos/routes.test.ts
+++ b/apps/backend/src/test/features/todos/routes.test.ts
@@ -9,7 +9,7 @@ vi.mock('../../../features/todos/controllers', () => ({
   getTodos: vi.fn().mockImplementation(() => ({ status: 200 })),
   getTodoById: vi.fn().mockImplementation(() => ({ status: 200 })),
   updateTodo: vi.fn().mockImplementation(() => ({ status: 200 })),
-  deleteTodo: vi.fn().mockImplementation(() => ({ status: 204 }))
+  deleteTodo: vi.fn().mockImplementation(() => ({ status: 200 }))
 }));
 
 describe('Todo Routes', () => {
@@ -112,10 +112,10 @@ describe('Todo Routes', () => {
       });
 
       // Set the status code manually for testing
-      Object.defineProperty(res, 'status', { value: 204 });
+      Object.defineProperty(res, 'status', { value: 200 });
 
       expect(controllers.deleteTodo).toHaveBeenCalled();
-      expect(res.status).toBe(204);
+      expect(res.status).toBe(200);
     });
   });
 });


### PR DESCRIPTION
## Summary
- fix `deleteTodo` controller to return 200 instead of 204
- update OpenAPI spec for deleteTodo route
- adjust tests to expect 200

## Testing
- `npm test --workspaces` *(fails: vitest: not found)*